### PR TITLE
Modernize chatbot theme

### DIFF
--- a/miniprogram/components/agent-ui/index.js
+++ b/miniprogram/components/agent-ui/index.js
@@ -136,7 +136,8 @@ Component({
     pendingImageUrl: '', // public URL for Zhipu
     
     // Theme configuration - change this to switch themes
-    currentTheme: 'dark', // Options: 'blue', 'orange', 'green', 'dark', 'purple', 'pink', 'ocean', 'sunset', 'forest'
+    // Default to a bright ocean look instead of the previous dark mode
+    currentTheme: 'ocean', // Options: 'blue', 'orange', 'green', 'dark', 'purple', 'pink', 'ocean', 'sunset', 'forest'
     lastImageUrl: '', // Store the last used image URL
   },
   attached: async function () {

--- a/miniprogram/components/agent-ui/index.wxss
+++ b/miniprogram/components/agent-ui/index.wxss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   overflow:hidden;
-  color: #344e41;
+  color: #333333;
   background-color: #f5f7f3;
   overflow: hidden;
   touch-action: none; /* 增强禁止滚动效果 */
@@ -61,7 +61,7 @@
   align-items: center;
   gap: 12px;
   width: 100%;
-  color: #588157;
+  color: #007AFF;
   font-size: 12px;
   height: 32px;
   margin-bottom: 16px;
@@ -74,7 +74,7 @@
   transform: scaleY(.5);
   flex-grow: 1;
   border-radius: 2px;
-  background-image: linear-gradient(to right, #a3b18a, rgba(0,0,0,0));
+  background-image: linear-gradient(to right, #90CAF9, rgba(0,0,0,0));
 }
 
 .nav-content {
@@ -108,8 +108,8 @@
 
 .share_btn, .tool_box .function {
   background-color: #fff !important;
-  color: #344e41 !important;
-  border: 2px solid #a3b18a !important;
+  color: #333333 !important;
+  border: 2px solid #90CAF9 !important;
   border-radius: 12rpx;
   transition: background 0.2s, color 0.2s, border 0.2s;
 }
@@ -136,7 +136,7 @@
   display: inline-block;
   font-size: 14px;
   font-weight: 300;
-  color: #344e41;
+  color: #333333;
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2rpx 8rpx rgba(44, 62, 80, 0.04);
@@ -300,7 +300,7 @@
 .text_desc {
   font-weight: bold !important;
   font-size: 24rpx;
-  color: #344e41;
+  color: #333333;
 }
 
 .input_inner_box {
@@ -310,7 +310,7 @@
   /* background-color: #fff; */
   display: flex;
   align-items: center;
-  border: 1px solid #a3b18a;
+  border: 1px solid #90CAF9;
   border-radius: 18rpx;
   /* box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2); */ 
   box-sizing: border-box;
@@ -326,7 +326,7 @@
 
 .input {
   padding: 8px;
-  color: #344e41;
+  color: #333333;
   width: 100%;
   flex: 1;
   max-height: 160px;
@@ -379,7 +379,7 @@
   box-sizing: border-box;
   position: relative;
   background-color: #f5f7f3;
-  color: #344e41;
+  color: #333333;
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2rpx 8rpx rgba(44, 62, 80, 0.04);
@@ -415,7 +415,7 @@
 .userContent {
   margin-top: 12px;
   padding-bottom: 16px;
-  background-color: #a3b18a;
+  background-color: #90CAF9;
   border-radius: 12rpx 0rpx 12rpx 12rpx;
   margin-left: 32rpx;
   margin-right: 32rpx;
@@ -448,7 +448,7 @@
 }
 
 .user .user_content {
-  background-color: #a3b18a;
+  background-color: #90CAF9;
   border-radius: 12rpx 0rpx 12rpx 12rpx;
   margin-left: 32rpx;
   margin-right: 32rpx;
@@ -464,7 +464,7 @@
   position: absolute;
   bottom: -120rpx;
   left: 0;
-  background: #344e41;
+  background: #333333;
   border-radius: 8rpx;
   display: flex;
   padding: 16rpx 24rpx;
@@ -560,7 +560,7 @@
   /* flex: 0 0 calc(25% - 20px); */
   background-color: #f4f8fb !important;
   color: #f5f7fa !important;
-  border: 2px solid #a3b18a;
+  border: 2px solid #90CAF9;
   box-shadow: 0 2rpx 8rpx rgba(163, 177, 138, 0.06);
   transition: background 0.2s, color 0.2s, border 0.2s;
   border-radius: 18rpx;
@@ -589,7 +589,7 @@
 }
 
 .feature_enable {
-  background-color: #588157 !important;
+  background-color: #007AFF !important;
   color: #fff !important;
   border-color: rgba(0, 122, 255, 0.15);
 }
@@ -684,7 +684,7 @@
 
 .create-new-chat {
   border-radius: 8px;
-  background: #a3b18a;
+  background: #90CAF9;
   color: #fff;
   cursor: pointer;
   padding: 16rpx 24rpx;
@@ -726,7 +726,7 @@
 }
 
 .selected-con {
-  background-color: #588157;
+  background-color: #007AFF;
   color: #fff;
   transition: filter 0.4s;
 }
@@ -1013,7 +1013,8 @@ textarea::placeholder {
 
 /* Modern font for the whole page */
 .agent-ui, .ugc-header, .ugc-title, .ugc-desc, .ugc-card, .chat-bubble, .question_content, .footer, .function, .tool_box .function {
-  font-family: "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  /* Sleeker modern typeface */
+  font-family: "Inter", "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
 /* Remove gold border/shadow from card-like elements */


### PR DESCRIPTION
## Summary
- switch default theme to bright `ocean`
- update fonts to use Inter for a modern look
- refresh colors for a clean blue scheme

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm test` in `miniprogram` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870cd81e1b0832e9c211cc9a4ae0fe7